### PR TITLE
Fix du bug des NetworkBehaviours

### DIFF
--- a/Assets/Script/Ethan/Tchat/EmojiButton.cs
+++ b/Assets/Script/Ethan/Tchat/EmojiButton.cs
@@ -2,7 +2,7 @@ using TMPro;
 using UnityEngine;
 using Mirror;
 
-public class EmojiButton : NetworkBehaviour
+public class EmojiButton : MonoBehaviour
 {
     public EmojiFamily emojiFamilyToTakeIn;
 
@@ -10,10 +10,8 @@ public class EmojiButton : NetworkBehaviour
 
     private TextMeshProUGUI textToChangeToEmoji;
 
-    public override void OnStartLocalPlayer()
+    private void Start()
     {
-        base.OnStartLocalPlayer();
-
         textToChangeToEmoji = GetComponentInChildren<TextMeshProUGUI>();
 
         if(isQuestion())


### PR DESCRIPTION
"NetworkIdentity Player(Clone) has too many NetworkBehaviour components: only 64 NetworkBehaviour components are allowed in order to save bandwidth."

Passage de la classe EmojiButton en MonoBehaviour au lieu de NetworkBehaviour.